### PR TITLE
Fixed OpenGL not working at all in some cases (Fixes #15)

### DIFF
--- a/src/modules/bb/blitz2d.gl/blitz2d.gl.h
+++ b/src/modules/bb/blitz2d.gl/blitz2d.gl.h
@@ -204,7 +204,7 @@ public:
 		glFlush();
 	}
 	void set(){
-		glBindFramebuffer( GL_FRAMEBUFFER,0 );
+		//glBindFramebuffer( GL_FRAMEBUFFER,0 );
 		glDrawBuffer( mode );
 	}
 

--- a/src/modules/bb/runtime.glfw3/runtime.glfw3.cpp
+++ b/src/modules/bb/runtime.glfw3/runtime.glfw3.cpp
@@ -135,6 +135,16 @@ public:
 		back_canvas=d_new GLFW3DefaultCanvas( wnd,GL_BACK,0 );
 
 		def_font=(BBImageFont*)loadFont( "courier",12*bbDPIScaleY(),0 );
+		if (def_font == nullptr)
+		{
+/*#if _WIN32
+			MessageBox(glfwGetWin32Window(wnd), "Failed to load default font: Courier 12", "Error", MB_OK | MB_ICONERROR);
+#else
+			// TODO: Other platforms
+#endif*/
+
+			def_font = (BBImageFont*)loadFont("courier new", 12 * bbDPIScaleY(), 0);
+		}
 
 		gamma_ramp.size=256;
 		gamma_ramp.red=gamma_red;


### PR DESCRIPTION
This Fixes #15  

- Fixed glBindFramebuffer crashing (temporary fix until cause is found)
- Fixed courier font failing to load with OpenGL due to courier being a legacy font and is not supported by most font loaders. (if it fails to load Courier then use Courier New)